### PR TITLE
Fixes project resolution when Project#getProperty returns null

### DIFF
--- a/src/main/java/nz/co/trademe/gradle/includeme/IncludeMePlugin.kt
+++ b/src/main/java/nz/co/trademe/gradle/includeme/IncludeMePlugin.kt
@@ -108,7 +108,7 @@ class IncludeMePlugin : Plugin<PluginAware> {
         val parentSearchPath = listOf(settings.projectDirectory.parentFile?.absolutePath)
 
         val declaredSearchPaths = PropertiesHelper.findAllGradleProperties(settings)
-                .map {
+                .mapNotNull {
                     it.getProperty("includeme.searchpaths")
                 }
 


### PR DESCRIPTION
An issue which broke project resolution occurs when trying to get the the declared search paths of the consuming project. If the project doesn't define `includeme.searchpaths`, `getProperty` will return null. This results in `declaredSearchPaths` being a list of nulls, causing the `parentSearchPath` to be ignored.